### PR TITLE
Small change to client.js sync code

### DIFF
--- a/client.js
+++ b/client.js
@@ -89,7 +89,7 @@ Client.prototype.sync = function(jsonOrCb, cb) {
     var json = {};
     if(typeof jsonOrCb == 'object')
         json = jsonOrCb;
-    else(typeof jsonOrCb == 'function')
+    else if(typeof jsonOrCb == 'function')
         cb = jsonOrCb;
     return sc.sync(this.username, this.auth_token, json).then(function(data) {
         self.auth_token = data.auth_token;


### PR DESCRIPTION
Both conditions were firing when the 'jsonOrCb' parameter was an object. Added missing if.
