### PR TITLE
Remove excess semicolon

### DIFF
--- a/snapchat.js
+++ b/snapchat.js
@@ -237,7 +237,7 @@ e.upload = function upload(username, auth_token, stream, isVideo, cb) {
 	}).on('end', function(end) {
 	    req.end(end);
 	})
-    }).nodeify(cb);;
+    }).nodeify(cb);
 }
 
 /**


### PR DESCRIPTION
This will never be reached because it comes after the `return` statement.
